### PR TITLE
Added scale mode to not resize the image

### DIFF
--- a/Haneke/HNKCache.h
+++ b/Haneke/HNKCache.h
@@ -154,7 +154,8 @@ typedef NS_ENUM(NSInteger, HNKScaleMode)
 {
     HNKScaleModeFill = UIViewContentModeScaleToFill,
     HNKScaleModeAspectFit = UIViewContentModeScaleAspectFit,
-    HNKScaleModeAspectFill = UIViewContentModeScaleAspectFill
+    HNKScaleModeAspectFill = UIViewContentModeScaleAspectFill,
+    HNKScaleModeNoScale
 };
 
 typedef NS_ENUM(NSInteger, HNKPreloadPolicy)
@@ -176,7 +177,6 @@ typedef NS_ENUM(NSInteger, HNKPreloadPolicy)
 
 /**
  The quality of the resulting JPEG image, expressed as a value from 0.0 to 1.0. The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents the least compression (or best quality). 1.0 by default.
- @discussion Only affects opaque images.
  */
 @property (nonatomic, assign) CGFloat compressionQuality;
 

--- a/Haneke/HNKCache.h
+++ b/Haneke/HNKCache.h
@@ -155,7 +155,7 @@ typedef NS_ENUM(NSInteger, HNKScaleMode)
     HNKScaleModeFill = UIViewContentModeScaleToFill,
     HNKScaleModeAspectFit = UIViewContentModeScaleAspectFit,
     HNKScaleModeAspectFill = UIViewContentModeScaleAspectFill,
-    HNKScaleModeNoScale
+    HNKScaleModeNone
 };
 
 typedef NS_ENUM(NSInteger, HNKPreloadPolicy)
@@ -177,6 +177,7 @@ typedef NS_ENUM(NSInteger, HNKPreloadPolicy)
 
 /**
  The quality of the resulting JPEG image, expressed as a value from 0.0 to 1.0. The value 0.0 represents the maximum compression (or lowest quality) while the value 1.0 represents the least compression (or best quality). 1.0 by default.
+ @discussion Only affects opaque images.
  */
 @property (nonatomic, assign) CGFloat compressionQuality;
 

--- a/Haneke/HNKCache.m
+++ b/Haneke/HNKCache.m
@@ -623,6 +623,8 @@ NSString *const HNKErrorDomain = @"com.hpique.haneke";
         case HNKScaleModeFill:
             resizedSize = formatSize;
             break;
+        case HNKScaleModeNoScale:
+            return originalImage;
     }
     const CGSize originalSize = originalImage.size;
     if (!self.allowUpscaling)

--- a/Haneke/HNKCache.m
+++ b/Haneke/HNKCache.m
@@ -623,7 +623,7 @@ NSString *const HNKErrorDomain = @"com.hpique.haneke";
         case HNKScaleModeFill:
             resizedSize = formatSize;
             break;
-        case HNKScaleModeNoScale:
+        case HNKScaleModeNone:
             return originalImage;
     }
     const CGSize originalSize = originalImage.size;

--- a/Haneke/UIImageView+Haneke.m
+++ b/Haneke/UIImageView+Haneke.m
@@ -38,6 +38,8 @@ static NSString *NSStringFromHNKScaleMode(HNKScaleMode scaleMode)
             return @"aspectfill";
         case HNKScaleModeAspectFit:
             return @"aspectfit";
+        case HNKScaleModeNone:
+            return @"scalenone";
     }
     return nil;
 }


### PR DESCRIPTION
Sometimes you don't want to have the image resized (I want to zoom into the image), so I've added a new scale mode that avoid the image scaling.
If you use it the format.size will be useless.
