### PR TITLE
removeAllImages doesn't rebuild disk cache

### DIFF
--- a/Haneke/HNKDiskCache.m
+++ b/Haneke/HNKDiskCache.m
@@ -123,6 +123,11 @@ NSString *const HNKExtendedFileAttributeKey = @"io.haneke.key";
         if ([[NSFileManager defaultManager] removeItemAtPath:_directory error:&error])
         {
             _size = 0;
+            
+            if (![[NSFileManager defaultManager] createDirectoryAtPath:_directory withIntermediateDirectories:YES attributes:nil error:&error])
+            {
+                NSLog(@"Failed to recreate directory with error %@", error);
+            }
         }
         else
         {


### PR DESCRIPTION
Calling removeAllImages on HNKCache causes each format to delete its
disk cache directory permanently, leading to cache write errors
following the call.

The solution is for a format to rebuild its cache directory after
removing it.
