### PR TITLE
Add a template method to prepare a NSURLSessionDataTask before it is resumed

### DIFF
--- a/Haneke/HNKNetworkFetcher.h
+++ b/Haneke/HNKNetworkFetcher.h
@@ -55,6 +55,8 @@ enum
 
 @interface HNKNetworkFetcher (Subclassing)
 
+- (void)prepareURLSessionDataTask:(NSURLSessionDataTask *)task;
+
 /**
  Returns the URL sessions used to download the image. Override to use a custom session. Uses sharedSession by default.
  */

--- a/Haneke/HNKNetworkFetcher.m
+++ b/Haneke/HNKNetworkFetcher.m
@@ -106,6 +106,9 @@
         });
         
     }];
+    
+    [self prepareURLSessionDataTask:_dataTask];
+    
     [_dataTask resume];
 }
 
@@ -137,6 +140,11 @@
 @end
 
 @implementation HNKNetworkFetcher(Subclassing)
+
+- (void)prepareURLSessionDataTask:(NSURLSessionDataTask *)task
+{
+    // Do nothing
+}
 
 - (NSURLSession*)URLSession
 {


### PR DESCRIPTION
You can override this method in your HNKNetworkFetcher subclass to set a task's priority, for instance.