### PR TITLE
UIImageView sets image immediately if animated == NO

### DIFF
--- a/Haneke/HNKCache.h
+++ b/Haneke/HNKCache.h
@@ -89,6 +89,14 @@
  */
 - (BOOL)fetchImageForKey:(NSString*)key formatName:(NSString *)formatName success:(void (^)(UIImage *image))successBlock failure:(void (^)(NSError *error))failureBlock;
 
+/**
+Retrieves an image from the memory cache.
+@param key Image cache key.
+@param formatName Name of the format in which the image is desired. The format must have been previously registered with the cache.
+@return The image if image exists in the memory cache, nil otherwise.
+*/
+- (UIImage *)fetchImageFromMemoryForKey:(NSString *)key formatName:(NSString *)formatName;
+
 #pragma mark Setting images
 ///---------------------------------------------
 /// @name Setting images

--- a/Haneke/HNKCache.m
+++ b/Haneke/HNKCache.m
@@ -155,17 +155,13 @@ NSString *const HNKErrorDomain = @"com.hpique.haneke";
 {
     HNKCacheFormat *format = _formats[formatName];
     NSAssert(format, @"Unknown format %@", formatName);
-    format.requestCount++;
     
-    UIImage *image = [self memoryImageForKey:key format:format];
+    UIImage *image = [self fetchImageFromMemoryForKey:key formatName:formatName];
     if (image)
     {
-        HanekeLog(@"Memory cache hit: %@/%@", formatName, key.lastPathComponent);
         if (successBlock) successBlock(image);
-        [self updateAccessDateOfImage:image key:key format:format];
         return YES;
     }
-    HanekeLog(@"Memory cache miss: %@/%@", formatName, key.lastPathComponent);
     
     [format.diskCache fetchDataForKey:key success:^(NSData *data) {
         HanekeLog(@"Disk cache hit: %@/%@", formatName, key.lastPathComponent);
@@ -204,6 +200,22 @@ NSString *const HNKErrorDomain = @"com.hpique.haneke";
         }
     }];
     return NO;
+}
+
+- (UIImage *)fetchImageFromMemoryForKey:(NSString *)key formatName:(NSString *)formatName
+{
+    HNKCacheFormat *format = _formats[formatName];
+    NSAssert(format, @"Unknown format %@", formatName);
+    format.requestCount++;
+    UIImage *image = [self memoryImageForKey:key format:format];
+    if (image)
+    {
+        HanekeLog(@"Memory cache hit: %@/%@", formatName, key.lastPathComponent);
+        [self updateAccessDateOfImage:image key:key format:format];
+    } else {
+        HanekeLog(@"Memory cache miss: %@/%@", formatName, key.lastPathComponent);
+    }
+    return image;
 }
 
 #pragma mark Setting images

--- a/Haneke/UIImageView+Haneke.m
+++ b/Haneke/UIImageView+Haneke.m
@@ -158,10 +158,16 @@
     }
     else
     {
-        const NSTimeInterval duration = animated ? 0.1 : 0;
-        [UIView transitionWithView:self duration:duration options:UIViewAnimationOptionTransitionCrossDissolve animations:^{
+        if (animated)
+        {
+            [UIView transitionWithView:self duration:0.1 options:UIViewAnimationOptionTransitionCrossDissolve animations:^{
+                self.image = image;
+            } completion:nil];
+        }
+        else
+        {
             self.image = image;
-        } completion:nil];
+        }
     }
 }
 


### PR DESCRIPTION
When using a Haneke UIImageView in a UICollectionViewCell, a reload can cause the cell to flicker if the image has been set to nil in `prepareForReuse`. This is due to the set image animation happening as an animation with duration 0 rather than directly setting the image (when `animated` is set to NO due to the image loading synchronously).