### PR TITLE
Ability to change directory for cache, ability to set key for HNKDiskCache

### DIFF
--- a/Haneke/HNKCache.h
+++ b/Haneke/HNKCache.h
@@ -46,6 +46,19 @@
 - (id)initWithName:(NSString*)name;
 
 /**
+ Initializes a cache with the given name.
+ @param name Name of the cache. Used as the name for the subdirectory of the disk cache.
+ @param directory Path of an existing directory. Used as directory of the disk cache.
+ */
+- (id)initWithName:(NSString*)name directory:(NSString *)directory;
+
+/**
+ Sets the shared cache with the given cache.
+ @param cache Instance of the cache. Used by the UIKit categories.
+ */
++ (void)setSharedCache:(HNKCache *)cache;
+
+/**
  Returns the shared cache used by the UIKit categories.
  @discussion It is recommended to use the shared cache unless you need separate caches.
  */

--- a/Haneke/HNKCache.m
+++ b/Haneke/HNKCache.m
@@ -69,15 +69,20 @@ NSString *const HNKErrorDomain = @"com.hpique.haneke";
 
 - (id)initWithName:(NSString*)name
 {
+    NSString *cachesDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+    return [self initWithName:name directory:cachesDirectory];
+}
+
+- (id)initWithName:(NSString*)name directory:(NSString *)directory
+{
     self = [super init];
     if (self)
     {
         _memoryCaches = [NSMutableDictionary dictionary];
         _formats = [NSMutableDictionary dictionary];
         
-        NSString *cachesDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject];
-        static NSString *cachePathComponent = @"com.hpique.haneke";
-        NSString *path = [cachesDirectory stringByAppendingPathComponent:cachePathComponent];
+        static NSString *subdirectoryPathComponent = @"com.hpique.haneke";
+        NSString *path = [directory stringByAppendingPathComponent:subdirectoryPathComponent];
         _rootDirectory = [path stringByAppendingPathComponent:name];
         
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didReceiveMemoryWarning:) name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
@@ -90,15 +95,30 @@ NSString *const HNKErrorDomain = @"com.hpique.haneke";
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
 }
 
+static HNKCache *sharedCache = nil;
+
 + (HNKCache*)sharedCache
 {
-    static HNKCache *instance = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        instance = [[HNKCache alloc] initWithName:@"shared"];
-    });
-    return instance;
+    if (sharedCache)
+    {
+        return sharedCache;
+    }
+    else
+    {
+        static HNKCache *instance = nil;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            instance = [[HNKCache alloc] initWithName:@"shared"];
+        });
+        return instance;
+    }
 }
+
++ (void)setSharedCache:(HNKCache *)cache
+{
+    sharedCache = cache;
+}
+
 
 - (void)registerFormat:(HNKCacheFormat *)format
 {

--- a/Haneke/HNKDiskFetcher.h
+++ b/Haneke/HNKDiskFetcher.h
@@ -34,8 +34,16 @@ enum
 /**
  Initializes a fetcher with the given path.
  @param path Image path.
+ @warning Key will be equal to path. Path to the application directory (Documents, Caches, etc) can be different after relaunch application.
  */
 - (instancetype)initWithPath:(NSString*)path;
+
+/**
+ Initializes a fetcher with the given path and key.
+ @param path Image path.
+ @param path Image key.
+ */
+- (instancetype)initWithPath:(NSString*)path andKey:(NSString *)key;
 
 /**
  Cancels the current fetch. When a fetch is cancelled it should not call any of the provided blocks.

--- a/Haneke/HNKDiskFetcher.m
+++ b/Haneke/HNKDiskFetcher.m
@@ -22,21 +22,28 @@
 
 @implementation HNKDiskFetcher {
     NSString *_path;
+    NSString *_key;
     BOOL _cancelled;
 }
 
 - (instancetype)initWithPath:(NSString*)path
 {
+    return [self initWithPath:path andKey:path];
+}
+
+- (instancetype)initWithPath:(NSString*)path andKey:(NSString *)key
+{
     if (self = [super init])
     {
         _path = path;
+        _key = key;
     }
     return self;
 }
 
 - (NSString*)key
 {
-    return _path;
+    return _key;
 }
 
 - (void)fetchImageWithSuccess:(void (^)(UIImage *image))successBlock failure:(void (^)(NSError *error))failureBlock;


### PR DESCRIPTION
I added ability to setting custom directory for HNKCache because OS can clean caches directory and recreating cache for all image formats can be very slow and use a lot of memory. Also I added ability to change shared cache for use cache with custom directory in UIKit categories.
I added ability to setting custom key for HNKDiskCache because path to the application directories (Documents, Caches, etc) can changes after relaunch application so it can't be used as key.
