### PR TITLE
Compilerwarnings

### DIFF
--- a/Haneke/UIButton+Haneke.h
+++ b/Haneke/UIButton+Haneke.h
@@ -111,7 +111,7 @@
  @discussion If needed, the least recently used images in the cache will be evicted in background.
  @warning If a success block is provided you will be responsible for setting the image.
  */
-- (void)hnk_setImage:(UIImage*)image withKey:(NSString*)key forState:(UIControlState)state placeholder:(UIImage*)placeholder success:(void (^)(UIImage *image))successBlock failure:(void (^)(NSError *error))failureBlock;
+- (void)hnk_setImage:(UIImage *)image withKey:(NSString *)key forState:(UIControlState)state placeholder:(UIImage *)placeholder success:(void (^)(UIImage *fetchedImage))successBlock failure:(void (^)(NSError *error))failureBlock;
 
 /** Loads, resizes, displays and caches an appropiately sized foreground image from the given fetcher.
  @param fetcher Fetcher from which the original image will be retrieved if needed. The fetcher will have to provide the original image only if it can't be found in the cache.

--- a/Haneke/UIButton+Haneke.m
+++ b/Haneke/UIButton+Haneke.m
@@ -71,7 +71,7 @@
     [self hnk_setImage:image withKey:key forState:state placeholder:placeholder success:nil failure:nil];
 }
 
-- (void)hnk_setImage:(UIImage*)image withKey:(NSString*)key forState:(UIControlState)state placeholder:(UIImage*)placeholder success:(void (^)(UIImage *image))successBlock failure:(void (^)(NSError *error))failureBlock
+- (void)hnk_setImage:(UIImage *)image withKey:(NSString *)key forState:(UIControlState)state placeholder:(UIImage *)placeholder success:(void (^)(UIImage *fetchedImage))successBlock failure:(void (^)(NSError *error))failureBlock
 {
     id<HNKFetcher> fetcher = [[HNKSimpleFetcher alloc] initWithKey:key image:image];
     [self hnk_setImageFromFetcher:fetcher forState:state placeholder:placeholder success:successBlock failure:failureBlock];

--- a/Haneke/UIImageView+Haneke.h
+++ b/Haneke/UIImageView+Haneke.h
@@ -100,7 +100,7 @@
  @discussion If needed, the least recently used images in the cache will be evicted in background.
  @warning If a success block is provided you will be responsible for setting the image.
  */
-- (void)hnk_setImage:(UIImage*)image withKey:(NSString*)key placeholder:(UIImage*)placeholder success:(void (^)(UIImage *image))successBlock failure:(void (^)(NSError *error))failureBlock;
+- (void)hnk_setImage:(UIImage *)image withKey:(NSString *)key placeholder:(UIImage *)placeholder success:(void (^)(UIImage *fetchedImage))successBlock failure:(void (^)(NSError *error))failureBlock;
 
 /** Loads, resizes, displays and caches an appropiately sized image from the given fetcher.
  @param fetcher Fetcher from which the original image will be retrieved if needed. The fetcher will have to provide the original image only if it can't be found in the cache.

--- a/Haneke/UIImageView+Haneke.m
+++ b/Haneke/UIImageView+Haneke.m
@@ -69,7 +69,7 @@
     [self hnk_setImage:originalImage withKey:key placeholder:placeholder success:nil failure:nil];
 }
 
-- (void)hnk_setImage:(UIImage*)originalImage withKey:(NSString*)key placeholder:(UIImage*)placeholder success:(void (^)(UIImage *image))successBlock failure:(void (^)(NSError *error))failureBlock
+- (void)hnk_setImage:(UIImage *)originalImage withKey:(NSString *)key placeholder:(UIImage *)placeholder success:(void (^)(UIImage *fetchedImage))successBlock failure:(void (^)(NSError *error))failureBlock
 {
     id<HNKFetcher> fetcher = [[HNKSimpleFetcher alloc] initWithKey:key image:originalImage];
     [self hnk_setImageFromFetcher:fetcher placeholder:placeholder success:successBlock failure:failureBlock];

--- a/Haneke/UIView+Haneke.m
+++ b/Haneke/UIView+Haneke.m
@@ -19,8 +19,6 @@
 //
 
 #import "UIView+Haneke.h"
-#import "HNKCache.h"
-#import <objc/runtime.h>
 
 const CGFloat HNKViewFormatCompressionQuality = 0.75;
 const unsigned long long HNKViewFormatDiskCapacity = 50 * 1024 * 1024;


### PR DESCRIPTION
There's nothing wrong with any of the code, but I wanted to fix some of the compiler warnings. Some of these changes does affect the method signatures for the blocks. Using the same variable name within a block doesn't always cause problems, but it most definitely creates developer confusion.
